### PR TITLE
Bugfix: RDM post_midcast RefreshSelf never gets invoked

### DIFF
--- a/Arislan-RDM.lua
+++ b/Arislan-RDM.lua
@@ -1172,7 +1172,7 @@ end
 -- eventArgs is the same one used in job_midcast, in case information needs to be persisted.
 function job_post_midcast(spell, action, spellMap, eventArgs)
     if spell.skill == 'Enhancing Magic' then
-        if classes.NoSkillSpells:contains(spell.english) then
+        if classes.NoSkillSpells:contains(spellMap) then
             equip(sets.midcast.EnhancingDuration)
             if spellMap == 'Refresh' then
                 equip(sets.midcast.Refresh)

--- a/Arislan-RDM.lua
+++ b/Arislan-RDM.lua
@@ -97,6 +97,9 @@ function job_setup()
     skill_spells = S{
         'Temper', 'Temper II', 'Enfire', 'Enfire II', 'Enblizzard', 'Enblizzard II', 'Enaero', 'Enaero II',
         'Enstone', 'Enstone II', 'Enthunder', 'Enthunder II', 'Enwater', 'Enwater II'}
+		
+	no_skill_spells_list = S{'Haste', 'Haste II', 'Refresh', 'Refresh II', 'Refresh III', 'Regen', 'Protect', 'Protectra', 'Shell', 'Shellra',
+        'Raise', 'Reraise', 'Sneak', 'Invisible', 'Deodorize'}
 
     include('Mote-TreasureHunter')
 
@@ -1172,7 +1175,7 @@ end
 -- eventArgs is the same one used in job_midcast, in case information needs to be persisted.
 function job_post_midcast(spell, action, spellMap, eventArgs)
     if spell.skill == 'Enhancing Magic' then
-        if classes.NoSkillSpells:contains(spellMap) then
+        if no_skill_spells_list:contains(spell.english) or classes.NoSkillSpells:contains(spellMap) then
             equip(sets.midcast.EnhancingDuration)
             if spellMap == 'Refresh' then
                 equip(sets.midcast.Refresh)


### PR DESCRIPTION
classes.NoSkillSpells:contains(spell.english) does not equal true when using spells such as "Refresh III" and "Haste II" because they are not part of the NoSkillSpells included within Motes-Mappings.